### PR TITLE
Error en filtros y cambios minimos

### DIFF
--- a/frontend/src/components/imc/estadisticas/Estadisticas.tsx
+++ b/frontend/src/components/imc/estadisticas/Estadisticas.tsx
@@ -1,6 +1,10 @@
+import { Card } from "@/components/ui/card"
+
 const ImcEstadisticas = () => {
   return (
-    <div>Próximamente...</div>
+    <Card>
+      Próximamente...
+    </Card>
   )
 }
 

--- a/frontend/src/components/imc/historial/components/CategoriasField.tsx
+++ b/frontend/src/components/imc/historial/components/CategoriasField.tsx
@@ -38,6 +38,7 @@ export function CategoriasField({ control }: Props) {
             <Popover>
               <PopoverTrigger>
                 <Button
+                  type="button"
                   variant="outline"
                   className="w-52 justify-between cursor-pointer font-normal"
                 >

--- a/frontend/src/components/imc/historial/components/Filters.tsx
+++ b/frontend/src/components/imc/historial/components/Filters.tsx
@@ -44,7 +44,10 @@ export default function HistorialFilters({ onSubmit }: Props) {
           size="sm"
           type="button"
           variant="outline"
-          onClick={() => reset()}
+          onClick={() => {
+            reset()
+            handleSubmit(onFormSubmit)()
+          }}
         >
           Limpiar filtros
         </Button>


### PR DESCRIPTION
- Se ajustó el botón trigger del Popover de categorías para que no dispare el submit del formulario al abrirse.
- Se actualizó el botón "Limpiar filtros" en Filters para que no solo reinicie los valores por defecto, sino que también vuelva a aplicar los filtros inmediatamente, asegurando que la UI refleje el estado limpio sin necesidad de presionar otro botón. 
