### PR TITLE
wip: estadisticas service

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from './module/auth/auth.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { UsersModule } from './module/users/users.module';
+import { EstadisticasModule } from './module/estadisticas/estadisticas.module';
 
 @Module({
   imports: [
@@ -24,7 +25,8 @@ import { UsersModule } from './module/users/users.module';
     }),
     ImcModule,
     AuthModule,
-    UsersModule
+    UsersModule,
+    EstadisticasModule
   ],
 })
 

--- a/backend/src/module/estadisticas/estadisticas.controller.spec.ts
+++ b/backend/src/module/estadisticas/estadisticas.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EstadisticasController } from './estadisticas.controller';
+import { EstadisticasService } from './estadisticas.service';
+
+describe('EstadisticasController', () => {
+  let controller: EstadisticasController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EstadisticasController],
+      providers: [EstadisticasService],
+    }).compile();
+
+    controller = module.get<EstadisticasController>(EstadisticasController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/module/estadisticas/estadisticas.controller.ts
+++ b/backend/src/module/estadisticas/estadisticas.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "../auth/guards/auth.guard";
+import { ActiveUser } from "@/common/decorators/active-user.decorator";
+import { IUserActive } from "@/common/interfaces/user-active";
+import { EstadisticasService } from "./estadisticas.service";
+
+@Controller('estadisticas')
+@UseGuards(AuthGuard)
+export class EstadisticasController {
+  constructor(private readonly estadisticasService: EstadisticasService) { }
+
+  @Get()
+  getResumen(@ActiveUser() user: IUserActive) {
+    return this.estadisticasService.getResumen(user.id);
+  }
+
+  @Get('serie-imc')
+  getSerieIMC(@ActiveUser() user: IUserActive) {
+    return this.estadisticasService.getSerieIMC(user.id);
+  }
+
+  @Get('serie-peso')
+  getSeriePeso(@ActiveUser() user: IUserActive) {
+    return this.estadisticasService.getSeriePeso(user.id);
+  }
+
+  @Get('categorias')
+  getDistribucionCategorias(@ActiveUser() user: IUserActive) {
+    return this.estadisticasService.getDistribucionCategorias(user.id);
+  }
+}
+

--- a/backend/src/module/estadisticas/estadisticas.module.ts
+++ b/backend/src/module/estadisticas/estadisticas.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EstadisticasService } from './estadisticas.service';
+import { EstadisticasController } from './estadisticas.controller';
+
+@Module({
+  controllers: [EstadisticasController],
+  providers: [EstadisticasService],
+})
+export class EstadisticasModule {}

--- a/backend/src/module/estadisticas/estadisticas.service.spec.ts
+++ b/backend/src/module/estadisticas/estadisticas.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EstadisticasService } from './estadisticas.service';
+
+describe('EstadisticasService', () => {
+  let service: EstadisticasService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EstadisticasService],
+    }).compile();
+
+    service = module.get<EstadisticasService>(EstadisticasService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/module/estadisticas/estadisticas.service.ts
+++ b/backend/src/module/estadisticas/estadisticas.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@nestjs/common";
+import { EstadisticasRepository } from "./repositories/estadisticas.repository";
+
+@Injectable()
+export class EstadisticasService {
+  constructor(
+    private readonly estadisticasRepository: EstadisticasRepository,
+  ) { }
+
+  async getResumen(userId: number) {
+    const raw = await this.estadisticasRepository.getResumen(userId);
+    return {
+      promedio: parseFloat(raw.promedio) || 0,
+      minimo: parseFloat(raw.minimo) || 0,
+      maximo: parseFloat(raw.maximo) || 0,
+      total: parseInt(raw.total, 10) || 0,
+    };
+  }
+
+  async getSerieIMC(userId: number) {
+    return this.estadisticasRepository.getSerieIMC(userId);
+  }
+
+  async getSeriePeso(userId: number) {
+    return this.estadisticasRepository.getSeriePeso(userId);
+  }
+
+  async getDistribucionCategorias(userId: number) {
+    return this.estadisticasRepository.getDistribucionCategorias(userId);
+  }
+}
+

--- a/backend/src/module/estadisticas/repositories/estadisticas.repository.interface.ts
+++ b/backend/src/module/estadisticas/repositories/estadisticas.repository.interface.ts
@@ -1,0 +1,21 @@
+export interface IEstadisticasRepository {
+  getResumen(userId: number): Promise<{
+    promedio: string;
+    minimo: string;
+    maximo: string;
+    total: string;
+  }>;
+
+  getSerieIMC(userId: number): Promise<
+    { fecha: Date; imc: number }[]
+  >;
+
+  getSeriePeso(userId: number): Promise<
+    { fecha: Date; peso: number }[]
+  >;
+
+  getDistribucionCategorias(userId: number): Promise<
+    { categoria: string; count: string }[]
+  >;
+}
+

--- a/backend/src/module/estadisticas/repositories/estadisticas.repository.ts
+++ b/backend/src/module/estadisticas/repositories/estadisticas.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Imc } from "../../imc/entities/imc.entity";
+import { IEstadisticasRepository } from "./estadisticas.repository.interface";
+
+@Injectable()
+export class EstadisticasRepository implements IEstadisticasRepository {
+  constructor(
+    @InjectRepository(Imc)
+    private readonly repository: Repository<Imc>,
+  ) { }
+
+  async getResumen(userId: number) {
+    const qb = this.repository
+      .createQueryBuilder("imc")
+      .select([
+        "AVG(imc.imc) as promedio",
+        "MIN(imc.imc) as minimo",
+        "MAX(imc.imc) as maximo",
+        "COUNT(imc.id) as total",
+      ])
+      .where("imc.userId = :userId", { userId });
+
+    return qb.getRawOne();
+  }
+
+  async getSerieIMC(userId: number) {
+    return this.repository.find({
+      where: { user: { id: userId } },
+      order: { fecha: "ASC" },
+      select: ["fecha", "imc"],
+    });
+  }
+
+  async getSeriePeso(userId: number) {
+    return this.repository.find({
+      where: { user: { id: userId } },
+      order: { fecha: "ASC" },
+      select: ["fecha", "peso"],
+    });
+  }
+
+  async getDistribucionCategorias(userId: number) {
+    const qb = this.repository
+      .createQueryBuilder("imc")
+      .select("imc.categoria", "categoria")
+      .addSelect("COUNT(*)", "count")
+      .where("imc.userId = :userId", { userId })
+      .groupBy("imc.categoria");
+
+    return qb.getRawMany();
+  }
+}
+

--- a/frontend/src/components/imc/estadisticas/Estadisticas.tsx
+++ b/frontend/src/components/imc/estadisticas/Estadisticas.tsx
@@ -1,10 +1,10 @@
-import { Card } from "@/components/ui/card"
+import Data from "./components/Data"
 
 const ImcEstadisticas = () => {
   return (
-    <Card>
-      Próximamente...
-    </Card>
+    <div className="w-[50vw]">
+      <Data />
+    </div>
   )
 }
 

--- a/frontend/src/components/imc/estadisticas/components/Data.tsx
+++ b/frontend/src/components/imc/estadisticas/components/Data.tsx
@@ -1,0 +1,13 @@
+import { Card, CardHeader, CardTitle } from "@/components/ui/card"
+
+const Data = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Proximamente...</CardTitle>
+      </CardHeader>
+    </Card>
+  )
+}
+
+export default Data


### PR DESCRIPTION
**Descripción:**
Se agrega un módulo `estadisticas` al backend para exponer endpoints de análisis y visualización de datos de IMC y peso del usuario. Este módulo provee:

**Endpoints:**
- `GET /api/estadisticas `→ resumen con promedio, mínimo, máximo y total de registros.
- `GET /api/estadisticas/serie-imc` → evolución del IMC en el tiempo.
- `GET /api/estadisticas/serie-peso` → evolución del peso en el tiempo.
- `GET /api/estadisticas/categorias` → distribución por categorías de IMC.
Repository dedicado `EstadisticasRepository` para queries agregadas optimizadas sobre Postgres.
DTOs de respuesta para un consumo limpio por parte del frontend.
Integración con `ImcRepository `para lectura de datos existentes.

**Cambios principales:**
`src/estadisticas/estadisticas.module.ts`
`src/estadisticas/estadisticas.controller.ts`
`src/estadisticas/estadisticas.service.ts`
`src/estadisticas/repositories/estadisticas.repository.ts`
`src/estadisticas/repositories/estadisticas.repository.interface.ts`

**Notas:**
- Se mantiene separación de responsabilidades: `ImcRepository` → CRUD de registros; `EstadisticasRepository` → consultas agregadas.
- El frontend puede consumir los endpoints para construir dashboards de IMC y peso sin necesidad de lógica adicional.

**Seguridad:** los endpoints filtran automáticamente los datos por userId.

**WIP:**
**DTOs de salida:**
- Crear ResumenEstadisticasDto, SerieDto, DistribucionCategoriasDto para tipar correctamente los responses del service.
- Mapear correctamente los valores crudos de Postgres (string) a number en los DTOs.

**Controller:**
- Validación de autenticación y autorización.
- Manejo de errores y respuestas HTTP consistentes.

**Tests:**
- Unit tests para EstadisticasService y EstadisticasRepository.
- Integration tests para los endpoints, aunque no es prioridad ahora.
- Mockear ImcRepository en los tests de service.

**Frontend:**
- Crear el dashboard que consuma estos endpoints.
- Implementar gráficos de evolución de IMC/peso y distribución de categorías.
- KPI cards con promedio, mínimo, máximo, total y tendencias.

**Filtros opcionales:**
- Agregar filtros por rango de fechas o categorías en endpoints de serie temporal.
- Posible paginación si los historiales son muy grandes.